### PR TITLE
adding cache control env var

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ var createServer = require('http-server').createServer;\
 var dist = path.join('swaggerui', 'dist');\
 var replace = require('replace');\
 replace({regex: 'http.*swagger.json', replacement : process.env.API_URL, paths: ['/swaggerui/dist/swagger-ui/index.html'], recursive:false, silent:true,});\
-var swaggerUI = createServer({ root: dist, cors: true });\
+var swaggerUI = createServer({ root: dist, cors: true, cache: process.env.CACHE });\
 swaggerUI.listen(8888);" > /swaggerui/index.js
 
 EXPOSE 8888

--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ docker run -d --name swagguer-ui -p 8888:8888 sjeandeaux/docker-swagger-ui
 
 #override API URL
 docker run -d --name swagger-ui -p 8888:8888 -e "API_URL=YOUR_URL" sjeandeaux/docker-swagger-ui
+
+#set cache control headers. default is 3600 seconds, let's set it to 0
+docker run -d --name swagger-ui -p 8888:8888 -e "CACHE=0" sjeandeaux/docker-swagger-ui
 ```
 
 ## Build


### PR DESCRIPTION
It is handy for development to disable HTTP caching. Might be better to just allow for any kwargs to be passed in the environment, but thought I would keep the changes minimal. 